### PR TITLE
[FEAT] 워치 앱 심박수 측정  진행 / 중지 상태 표시, StartPage 심박수 수정

### DIFF
--- a/TopicRun/TopicRun.xcodeproj/project.pbxproj
+++ b/TopicRun/TopicRun.xcodeproj/project.pbxproj
@@ -691,7 +691,7 @@
 				CODE_SIGN_ENTITLEMENTS = TopicRun/TopicRunDebug.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = BQSHS2D2FB;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TopicRun/Info.plist;
 				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "Please give access to following Data";
@@ -726,7 +726,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = BQSHS2D2FB;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TopicRun/Info.plist;
 				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "Please give access to following Data";

--- a/TopicRun/TopicRun/HeartBeatViewController.swift
+++ b/TopicRun/TopicRun/HeartBeatViewController.swift
@@ -207,12 +207,12 @@ extension HeartBeatViewController {
     func workOutStop() {
         // AppleWatch에 [WorkOut 세션 종료] 명령 메시지 전달
         if self.isReachable() {
-            do {
-                timer.invalidate()
-                try self.session.updateApplicationContext(["action": "stop"])
-            } catch {
-                print("error")
-            }
+//            do {
+//                timer.invalidate()
+//                try self.session.updateApplicationContext(["action": "stop"])
+//            } catch {
+//                print("error")
+//            }
         } else {
             print("AppleWatch is not reachable...!")
         }

--- a/TopicRun/TopicRun/SceneDelegate.swift
+++ b/TopicRun/TopicRun/SceneDelegate.swift
@@ -11,7 +11,7 @@ import WatchConnectivity
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-
+    var session = WCSession.default
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
@@ -20,6 +20,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         if !SessionHandler.shared.isSupported() {
             print("WCSEssion not supported")
         }
+        
+        // AppleWatch에 [WorkOut 세션 시작] 명령 메시지 전달
+        do {
+            try self.session.updateApplicationContext(["action": "start"])
+        } catch {
+            print("error")
+        }
+        
         guard let _ = (scene as? UIWindowScene) else { return }
     }
 
@@ -33,6 +41,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneDidBecomeActive(_ scene: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+        // AppleWatch에 [WorkOut 세션 시작] 명령 메시지 전달
+        do {
+            try self.session.updateApplicationContext(["action": "start"])
+        } catch {
+            print("error")
+        }
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
@@ -43,6 +57,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
+        // AppleWatch에 [WorkOut 세션 시작] 명령 메시지 전달
+        do {
+            try self.session.updateApplicationContext(["action": "start"])
+        } catch {
+            print("error")
+        }
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {

--- a/TopicRun/TopicRun/StartPageView.storyboard
+++ b/TopicRun/TopicRun/StartPageView.storyboard
@@ -11,6 +11,7 @@
         <!--StartPageView-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <viewController storyboardIdentifier="StartPage" title="StartPageView" id="Y6W-OH-hqX" customClass="StartPageViewController" customModule="TopicRun" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
@@ -100,7 +101,6 @@
                         <outlet property="topicRunButton" destination="zIC-Eu-CZA" id="N74-a8-lIG"/>
                     </connections>
                 </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="989.23076923076917" y="105.21327014218009"/>
         </scene>

--- a/TopicRun/TopicRun/StartPageViewController.swift
+++ b/TopicRun/TopicRun/StartPageViewController.swift
@@ -18,11 +18,6 @@ class StartPageViewController: UIViewController, UITextFieldDelegate {
     @IBOutlet var heartRateLabel: UILabel!
     @IBOutlet weak var sceneInterface: SKView!
     
-    let healthStore = HKHealthStore()
-    let heartRateUnit:HKUnit = HKUnit(from: "count/min")
-    let heartRateType:HKQuantityType = HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.heartRate)!
-    var heartRateQuery:HKQuery?
-    
     // WCSession 프로퍼티 선언
     var session = WCSession.default
     var timer = Timer()
@@ -38,8 +33,9 @@ class StartPageViewController: UIViewController, UITextFieldDelegate {
             print("error")
         }
         
+        collectHeartRate()
+        
     }
-    
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -49,8 +45,6 @@ class StartPageViewController: UIViewController, UITextFieldDelegate {
             session.delegate = self
             session.activate()
         }
-        
-        collectHeartRate()
         
         // 키보드 사용 관련
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
@@ -64,6 +58,12 @@ class StartPageViewController: UIViewController, UITextFieldDelegate {
     
     @IBAction func topicRunButtonPressed(_ sender: UIButton) {
         timer.invalidate()
+//        // AppleWatch에 [WorkOut 세션 시작] 명령 메시지 전달
+//        do {
+//            try self.session.updateApplicationContext(["action": "start"])
+//        } catch {
+//            print("error")
+//        }
         view.endEditing(true)
     }
     
@@ -147,5 +147,9 @@ extension StartPageViewController: WCSessionDelegate {
     
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
         print("activationDidCompleteWith activationState:\(activationState) error: \(String(describing: error))")
+    }
+    
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
+        
     }
 }

--- a/TopicRun/TopicRunWatch WatchKit Extension/ExtensionDelegate.swift
+++ b/TopicRun/TopicRunWatch WatchKit Extension/ExtensionDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import WatchKit
+import WatchConnectivity
 
 class ExtensionDelegate: NSObject, WKExtensionDelegate {
 

--- a/TopicRun/TopicRunWatch WatchKit Extension/InterfaceController.swift
+++ b/TopicRun/TopicRunWatch WatchKit Extension/InterfaceController.swift
@@ -13,6 +13,7 @@ class InterfaceController: WKInterfaceController {
     
     @IBOutlet var sceneInterface: WKInterfaceSKScene!
     @IBOutlet weak var heartRateLabel: WKInterfaceLabel!
+    @IBOutlet var workOutStateLabel: WKInterfaceLabel!
     
     // WCSession 프로퍼티 선언
     private var session = WCSession.default
@@ -29,7 +30,7 @@ class InterfaceController: WKInterfaceController {
     
     override func awake(withContext context: Any?) {
         super.awake(withContext: context)
-        runWorkOut()
+        
         receiveMessage()
     }
     
@@ -134,17 +135,21 @@ class InterfaceController: WKInterfaceController {
     private func receiveMessage() {
         authorization { (success, healthkit) in
             
-            self.healthStore =  healthkit;
+            self.healthStore =  healthkit
             if(success){
         if WCSession.isSupported() {
+            print(WCSession.default.receivedApplicationContext)
             if let sendedWord = WCSession.default.receivedApplicationContext["action"] as? String {
                 print(sendedWord)
+                // "start" 명령을 받고, workOut Session이 진행중이지 않을 때 새로운 Session 시작
                 if sendedWord == "start" && !self.workOutFlag{
-                    self.runWorkOut()
                     self.workOutFlag = true
+                    self.workOutStateLabel.setText("")
+                    self.runWorkOut()
                 } else if sendedWord == "stop" {
-                    self.stopWorkOut()
                     self.workOutFlag = false
+                    self.workOutStateLabel.setText("심박수 측정이 \n일시정지된 상태입니다")
+                    self.stopWorkOut()
                 } else {
                     print("No Action Type")
                 }
@@ -174,6 +179,10 @@ class InterfaceController: WKInterfaceController {
 extension InterfaceController: WCSessionDelegate {
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
         print("activationDidCompleteWith activationState:\(activationState) error: \(String(describing: error))")
+    }
+    
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
+        
     }
 }
 

--- a/TopicRun/TopicRunWatch/Base.lproj/Interface.storyboard
+++ b/TopicRun/TopicRunWatch/Base.lproj/Interface.storyboard
@@ -22,6 +22,9 @@
                                             <variation key="device=watch44mm" height="115" width="136"/>
                                             <variation key="device=watch45mm" height="120"/>
                                         </label>
+                                        <label width="136" height="53" alignment="center" verticalAlignment="bottom" textAlignment="center" numberOfLines="2" id="QVH-iz-twd" userLabel="WorkOut State Label">
+                                            <fontDescription key="font" style="UICTFontTextStyleFootnote"/>
+                                        </label>
                                     </items>
                                 </group>
                             </items>
@@ -31,6 +34,7 @@
                     <connections>
                         <outlet property="heartRateLabel" destination="uoe-Jo-0z8" id="urQ-N9-88t"/>
                         <outlet property="sceneInterface" destination="KtJ-Uu-Lms" id="Rp7-7c-9Gw"/>
+                        <outlet property="workOutStateLabel" destination="QVH-iz-twd" id="ETd-da-rKx"/>
                     </connections>
                 </controller>
             </objects>


### PR DESCRIPTION
## 개요
* 워치 앱 심박수 측정  진행 / 중지 상태 표시
* StartPage 심박수 타이머가 제대로 작동하지 않던 부분 수정

### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
  - [X] 기능 추가
  - [ ] 기능 삭제
  - [ ] 버그 수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
4-feat-HealthKit-Watch-Label-Change -> dev

<br/>

## 작업사항 
### 작업 사항
* 워치 앱이 작동하는 동안 심박수 측정이 중단된 상태일 때를 확인하기 힘든 부분을 비활성화 상태일 때 메시지를 띄우는 방식으로 개선했습니다.
* StartPage 심박수 타이머가 제대로 작동하지 않던 부분을 수정하였습니다

### 테스트 결과 (스크린샷, GIF, 샘플 API 등 결과물)
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
이미지 이쁘게 넣는 코드를 아래 두니 참고해서 작성 

<br/>

